### PR TITLE
Add gitleaks secret scan

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,9 @@
+name: Secret scan
+on:
+  pull_request:
+  push:
+    branches: [main, master]
+
+jobs:
+  scan:
+    uses: Talieisin/.github/.github/workflows/secret-scan.yml@main


### PR DESCRIPTION
Wires in the org-wide gitleaks secret-scan reusable workflow. Runs on every PR + push to default branch. Replaces GitHub's paid Secret Protection with a free, org-unified gate.