### PR TITLE
Move exit-condition script to expected URL path + persistent marker

### DIFF
--- a/scripts/lib/exit-condition.sh
+++ b/scripts/lib/exit-condition.sh
@@ -2,11 +2,25 @@
 
 ############################################################################################
 ##
-## Script to Create Exit Condition File for Baseline Script
+## Script to Create Exit Condition File for SecondSon Baseline
 ##
 ## This script creates a marker file to signal that the Baseline script
-## should not execute again. It follows the structure and logging practices
-## of the provided local admin account creation script.
+## should not execute again. It MUST be the last script in the SecondSon
+## Scripts array to ensure all other scripts complete successfully first.
+##
+## The marker path MUST match var.baseline_exit_condition in the Terraform
+## (rendered into the SecondSon mobileconfig as ExitCondition). On its next
+## startup, Baseline checks that path and exits silently if it exists.
+##
+## The marker path is deliberately OUTSIDE /usr/local/Baseline/ because
+## Baseline's CleanupAfterUse=true deletes that directory after a
+## successful run, which would otherwise wipe the marker we just wrote.
+##
+## /var/db/ is a system path that survives reboots and Baseline cleanup,
+## and is wiped on a device reset/re-enrolment — which is the correct
+## behaviour (a wiped device should re-run baseline).
+##
+## IDEMPOTENT: Safe to re-run, checks if marker already exists
 ##
 ############################################################################################
 
@@ -14,7 +28,7 @@
 scriptname="Create Baseline Exit Condition"
 logdir="/Library/IntuneScripts/createBaselineExitCondition"
 log="$logdir/createBaselineExitCondition.log"
-exit_condition_file="/usr/local/Baseline/baseline_exit_condition"
+exit_condition_file="/var/db/.talieisin-baseline-complete"
 
 # Prepare logging directory
 if [[ -d $logdir ]]; then


### PR DESCRIPTION
## Why

The SecondSon Baseline lifecycle script reference rendered by the Terraform `secondson-baseline.mobileconfig.tpl` expects the script at:

```
https://raw.githubusercontent.com/Talieisin/macos-scripts/main/scripts/lib/exit-condition.sh
```

Previously the script lived at `config/baseline_exit_condition.sh`, so production ADE devices got 404s on download and Baseline's lifecycle Scripts array reported *"Script does not exist"* / *"Script download error"*. Test framework saw it too as `not ok 14 Baseline apps installed successfully (no failures)`.

## Changes

- Renames `config/baseline_exit_condition.sh` → `scripts/lib/exit-condition.sh` (git tracks as rename)
- Changes the marker file path from `/usr/local/Baseline/baseline_exit_condition` (which Baseline's `CleanupAfterUse=true` deletes immediately after the successful run, defeating the whole mechanism) to `/var/db/.talieisin-baseline-complete`
  - `/var/db/` persists across reboots and Baseline's own cleanup
  - Cleared on device wipe → correct re-run behaviour on re-enrolment
  - Cleared by `sudo rm` → escape hatch for IT support

## Coupled changes in Talieisin/intune (will land separately)

The marker path is now the **single source of truth** referenced from two places in the intune working tree:

- `var.baseline_exit_condition` default → rendered as `ExitCondition` in SecondSon mobileconfig (Baseline checks before doing anything)
- `bootstrap.sh` Phase 3 short-circuit → skips pkg install + Baseline launch entirely if marker exists (defense-in-depth)

Both will point at `/var/db/.talieisin-baseline-complete` to match this script.

## Important

This file must stay **byte-identical** to `scripts/lib/exit-condition.sh` in the Talieisin/intune working tree. The Terraform-rendered SecondSon mobileconfig pins the script's MD5, so any drift makes Baseline reject the download. Current MD5: `2e6894a49ca224e4bab4a9e0e2fe88f2`.

## Test plan

- [ ] CI / gitleaks workflow passes
- [ ] Visual diff confirms only the marker path string changed (plus expanded header comment)
- [ ] After this lands and the intune side is published, ADE devices should see Baseline lifecycle Scripts array complete without "Script download error"