### PR TITLE
Read marker path from managed prefs + record forensic version/timestamp

### DIFF
--- a/scripts/lib/exit-condition.sh
+++ b/scripts/lib/exit-condition.sh
@@ -2,43 +2,53 @@
 
 ############################################################################################
 ##
-## Script to Create Exit Condition File for SecondSon Baseline
+## Mark SecondSon Baseline as provisioned for this device.
 ##
-## This script creates a marker file to signal that the Baseline script
-## should not execute again. It MUST be the last script in the SecondSon
-## Scripts array to ensure all other scripts complete successfully first.
+## Final lifecycle script in the SecondSon Baseline Scripts array. Writes a
+## marker file that bootstrap.sh's Phase 3 short-circuit checks before
+## re-installing the Baseline pkg + re-running Baseline.
 ##
-## The marker path MUST match var.baseline_exit_condition in the Terraform
-## (rendered into the SecondSon mobileconfig as ExitCondition). On its next
-## startup, Baseline checks that path and exits silently if it exists.
+## SOURCE OF TRUTH for the marker path:
+##   `SECONDSON_BASELINE_EXIT_CONDITION` managed pref in
+##   /Library/Managed Preferences/com.talieisin.baseline.plist
+##   (rendered by Terraform from var.baseline_exit_condition).
 ##
-## The marker path is deliberately OUTSIDE /usr/local/Baseline/ because
-## Baseline's CleanupAfterUse=true deletes that directory after a
-## successful run, which would otherwise wipe the marker we just wrote.
+## The script reads that managed pref so the marker path is configurable
+## from Terraform without editing this script. If the pref is unset (which
+## shouldn't happen in normal operation), the script logs a warning and
+## exits without writing — Phase 3 will then re-run on the next bootstrap.
 ##
-## /var/db/ is a system path that survives reboots and Baseline cleanup,
-## and is wiped on a device reset/re-enrolment — which is the correct
-## behaviour (a wiped device should re-run baseline).
+## MARKER CONTENTS (forensic only, not parsed):
+##   version=<SECONDSON_BASELINE_VERSION>
+##   completed=<ISO 8601 UTC timestamp>
+##   hostname=<device name>
 ##
-## IDEMPOTENT: Safe to re-run, checks if marker already exists
+## bootstrap.sh treats the marker as a binary signal — presence = skip,
+## absence = run. The contents exist for IT support: `cat /var/db/...`
+## shows what version provisioned the device and when.
+##
+## Operator contract (see baseline/README.md):
+##   Bumping `var.secondson_baseline_version` does NOT auto-upgrade existing
+##   devices. To force re-run on the fleet, deploy a one-off Intune script
+##   that removes the marker, then redeploy bootstrap.sh.
+##
+## CleanupAfterUse=true deletes /usr/local/Baseline/ after a successful
+## Baseline run; we deliberately write to /var/db/ instead so the marker
+## survives. /var/db/ is also wiped on a device reset/re-enrolment — which
+## is the correct behaviour (a fresh device should re-run baseline).
+##
+## IDEMPOTENT: safe to re-run; overwrites the marker on each successful run.
 ##
 ############################################################################################
 
-# Define variables
 scriptname="Create Baseline Exit Condition"
 logdir="/Library/IntuneScripts/createBaselineExitCondition"
 log="$logdir/createBaselineExitCondition.log"
-exit_condition_file="/var/db/.talieisin-baseline-complete"
+pref_domain="com.talieisin.baseline"
+managed_prefs="/Library/Managed Preferences/$pref_domain"
 
 # Prepare logging directory
-if [[ -d $logdir ]]; then
-    echo "# $(date) | Log directory already exists - $logdir"
-else
-    echo "# $(date) | Creating log directory - $logdir"
-    mkdir -p "$logdir"
-fi
-
-# Start logging
+mkdir -p "$logdir"
 exec 1>> "$log" 2>&1
 
 echo ""
@@ -47,28 +57,38 @@ echo "# $(date) | Starting $scriptname"
 echo "##############################################################"
 echo ""
 
-# Check if exit condition file already exists
-if [[ -f "$exit_condition_file" ]]; then
-    echo "$(date) | Exit condition file already exists at $exit_condition_file"
-    echo "$(date) | No action needed. Exiting script."
-    exit 0
-else
-    echo "$(date) | Exit condition file not found. Proceeding to create it."
+# Read the marker path + version from managed prefs (the rendered mobileconfig
+# is the single source of truth for both).
+exit_condition_file=$(/usr/bin/defaults read "$managed_prefs" SECONDSON_BASELINE_EXIT_CONDITION 2>/dev/null || echo "")
+baseline_version=$(/usr/bin/defaults read "$managed_prefs" SECONDSON_BASELINE_VERSION 2>/dev/null || echo "unknown")
+
+if [[ -z "$exit_condition_file" ]]; then
+    echo "$(date) | ERROR: SECONDSON_BASELINE_EXIT_CONDITION not set in $managed_prefs"
+    echo "$(date) | Refusing to write marker without a configured path. Exiting."
+    exit 1
 fi
 
-# Create the directory for the exit condition file if it doesn't exist
+# Ensure parent dir exists (normally /var/db, which is always present).
 exit_condition_dir=$(dirname "$exit_condition_file")
 if [[ ! -d "$exit_condition_dir" ]]; then
-    echo "$(date) | Creating directory for exit condition file: $exit_condition_dir"
+    echo "$(date) | Creating parent directory: $exit_condition_dir"
     mkdir -p "$exit_condition_dir"
 fi
 
-# Create the exit condition file with a timestamp
-echo "$(date) | Creating exit condition file at $exit_condition_file"
-echo "Baseline script completed on $(date)" > "$exit_condition_file"
+# Write the marker file. Contents are forensic (not parsed by bootstrap.sh).
+# Overwrite unconditionally so re-runs after a force-remove + re-provision
+# capture the latest version/timestamp.
+echo "$(date) | Writing exit condition marker at $exit_condition_file"
+completed_ts=$(/bin/date -u +%Y-%m-%dT%H:%M:%SZ)
+hostname=$(/bin/hostname -s 2>/dev/null || echo "unknown")
+cat > "$exit_condition_file" <<EOF
+version=$baseline_version
+completed=$completed_ts
+hostname=$hostname
+EOF
 
-# Set appropriate permissions
 chmod 644 "$exit_condition_file"
-echo "$(date) | Set permissions to 644 for $exit_condition_file"
+chown root:wheel "$exit_condition_file" 2>/dev/null || true
 
-echo "$(date) | Exit condition file created successfully. Script completed."
+echo "$(date) | Marker written: version=$baseline_version completed=$completed_ts"
+echo "$(date) | Script completed successfully."


### PR DESCRIPTION
## Why

Three issues with the previous exit-condition script (#3):

1. **Marker path was hardcoded** — duplicated in three places (Terraform var default, bootstrap.sh fallback, this script). Changing any one silently broke the run-once contract.
2. **No forensic content** — IT couldn't tell what version of Baseline provisioned a given device, or when, by inspecting the marker.
3. **The script was a writer with no awareness of upstream configuration.**

## What changed

- **Marker path read from managed prefs.** The script now reads `SECONDSON_BASELINE_VERSION` and `SECONDSON_BASELINE_EXIT_CONDITION` from `/Library/Managed Preferences/com.talieisin.baseline.plist`. The Terraform-rendered mobileconfig is the **single source of truth** for both.

  If `SECONDSON_BASELINE_EXIT_CONDITION` is missing (shouldn't happen in normal operation), the script exits 1 — refuses to write a marker without a configured path.

- **Marker contents are now forensic:**
  ```
  version=v3.0
  completed=2026-05-14T08:30:00Z
  hostname=AWEN-001
  ```

  `bootstrap.sh` treats the marker as a **binary signal** — presence means "device provisioned, skip Phase 3". The contents exist for IT support: `cat /var/db/.talieisin-baseline-complete` shows what version provisioned and when. Not parsed for control flow.

- **Marker is overwritten unconditionally on each successful run** so a force-rerun (`sudo rm marker && re-run bootstrap.sh`) correctly captures the latest version/timestamp.

## Operator contract (documented in the script header)

Bumping `var.secondson_baseline_version` does **NOT** auto-upgrade existing devices. Existing devices stay on whatever Baseline version they got at ADE enrolment. To roll out a new Baseline version across an existing fleet:

1. Deploy a one-off Intune script that removes `/var/db/.talieisin-baseline-complete`
2. Redeploy `bootstrap.sh` (e.g. bump `MODULE_VERSION` so Intune re-dispatches)
3. Existing devices re-run Phase 3 → install + run new Baseline version

## Coupling with `Talieisin/intune`

This file must stay **byte-identical** to `scripts/lib/exit-condition.sh` in the intune working tree. The intune Terraform pins this file's MD5 via `filemd5()` into the rendered SecondSon mobileconfig — Baseline downloads the script at run-time and rejects it if MD5s differ.

The intune side now has a `data \"http\"` + `terraform_data` preflight that fetches the published content from the rendered raw-URL and **blocks `terraform plan`** if MD5s drift. So a missed push here will fail loud rather than silent.

Local MD5 after this PR merges: `f7314068dd2f79a651c0d747786ec5e8`.

## Test plan

- [ ] CI / gitleaks workflow passes
- [ ] On merge, intune's `terraform plan` unblocks (the preflight currently blocks because main is still on PR #3's content)
- [ ] Then re-run VM baseline test — expect marker contents to show `version=v3.0` + ISO timestamp